### PR TITLE
ListMonk-Synchronisation der Mitglieder (Name + E-Mail)

### DIFF
--- a/app/Classes/Bootstrap.php
+++ b/app/Classes/Bootstrap.php
@@ -16,6 +16,7 @@ use App\Repository\UserRepository;
 use App\Service\CurrentUser;
 use App\Service\EmailService;
 use App\Service\Ldap;
+use App\Service\Listmonk;
 use Hengeb\Router\Exception\InvalidRouteException;
 use Hengeb\Router\Interface\CurrentUserInterface;
 use Hengeb\Router\LatteExtension;
@@ -79,6 +80,16 @@ class Bootstrap extends ServiceContainer {
             bindPassword: getenv('LDAP_BIND_PASSWORD'),
             peopleDn: getenv('LDAP_PEOPLE_DN'),
             groupsDn: getenv('LDAP_GROUPS_DN'),
+        ));
+    }
+
+    public function getListmonk(): Listmonk
+    {
+        return $this->createService(Listmonk::class, fn() => new Listmonk(
+            baseUrl: getenv('LISTMONK_URL') ?: '',
+            apiUser: getenv('LISTMONK_USER') ?: '',
+            apiToken: getenv('LISTMONK_TOKEN') ?: '',
+            listId: (int) (getenv('LISTMONK_LIST_ID') ?: 0),
         ));
     }
 

--- a/app/Classes/Controller/ListmonkController.php
+++ b/app/Classes/Controller/ListmonkController.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * @license https://creativecommons.org/publicdomain/zero/1.0/ CC0 1.0
+ */
+
+declare(strict_types=1);
+namespace App\Controller;
+
+use App\Service\Ldap;
+use App\Service\Listmonk;
+use Hengeb\Router\Attribute\AllowIf;
+use Hengeb\Router\Attribute\CheckCsrfToken;
+use Hengeb\Router\Attribute\PublicAccess;
+use Hengeb\Router\Attribute\Route;
+use Hengeb\Router\Exception\AccessDeniedException;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Synchronisation der Mitglieder (Name + E-Mail) mit einer ListMonk-Instanz.
+ */
+class ListmonkController extends Controller {
+    /**
+     * Synchronisation manuell aus dem Admin-Bereich auslösen.
+     */
+    #[Route('POST /admin/listmonk-sync'), AllowIf(role: 'newsletter-export')]
+    public function syncFromAdmin(Ldap $ldap, Listmonk $listmonk): Response {
+        $result = $listmonk->sync($ldap->getAll());
+        return $this->render('ListmonkController/sync-result', ['result' => $result]);
+    }
+
+    /**
+     * Synchronisation per token-geschütztem Endpoint für einen externen Cronjob.
+     */
+    #[Route('GET /cron/listmonk-sync'), PublicAccess, CheckCsrfToken(false)]
+    public function syncFromCron(Ldap $ldap, Listmonk $listmonk): Response {
+        $expected = getenv('LISTMONK_SYNC_TOKEN') ?: '';
+        $given = (string) $this->request->query->get('token', '');
+        if ($expected === '' || !hash_equals($expected, $given)) {
+            throw new AccessDeniedException();
+        }
+        $result = $listmonk->sync($ldap->getAll());
+        return $this->json($result);
+    }
+}

--- a/app/Classes/Controller/ListmonkController.php
+++ b/app/Classes/Controller/ListmonkController.php
@@ -9,7 +9,6 @@ namespace App\Controller;
 use App\Service\Ldap;
 use App\Service\Listmonk;
 use Hengeb\Router\Attribute\AllowIf;
-use Hengeb\Router\Attribute\CheckCsrfToken;
 use Hengeb\Router\Attribute\PublicAccess;
 use Hengeb\Router\Attribute\Route;
 use Hengeb\Router\Exception\AccessDeniedException;
@@ -31,7 +30,7 @@ class ListmonkController extends Controller {
     /**
      * Synchronisation per token-geschütztem Endpoint für einen externen Cronjob.
      */
-    #[Route('GET /cron/listmonk-sync'), PublicAccess, CheckCsrfToken(false)]
+    #[Route('GET /cron/listmonk-sync'), PublicAccess]
     public function syncFromCron(Ldap $ldap, Listmonk $listmonk): Response {
         $expected = getenv('LISTMONK_SYNC_TOKEN') ?: '';
         $given = (string) $this->request->query->get('token', '');

--- a/app/Classes/Service/Listmonk.php
+++ b/app/Classes/Service/Listmonk.php
@@ -1,0 +1,311 @@
+<?php
+declare(strict_types=1);
+namespace App\Service;
+
+/**
+ * @license https://creativecommons.org/publicdomain/zero/1.0/ CC0 1.0
+ */
+
+/**
+ * Synchronisiert Namen und E-Mail-Adressen der Mitglieder mit einer ListMonk-Instanz.
+ *
+ * Quelle der Wahrheit sind die Mitgliederdaten (per Ldap::getAll() ermittelt und vom Controller
+ * hereingereicht); ListMonk wird abgeglichen. Dieser Service kennt das LDAP selbst nicht.
+ */
+class Listmonk
+{
+    public function __construct(
+        private string $baseUrl,
+        private string $apiUser,
+        private string $apiToken,
+        private int $listId,
+    ) {
+        $this->baseUrl = rtrim($this->baseUrl, '/');
+    }
+
+    /**
+     * Ist die Anbindung vollständig konfiguriert? Ohne Konfiguration bleibt das Feature inaktiv.
+     */
+    public function isConfigured(): bool
+    {
+        return $this->baseUrl !== '' && $this->apiUser !== '' && $this->apiToken !== '' && $this->listId > 0;
+    }
+
+    /**
+     * Gleicht die übergebenen Mitglieder mit der Ziel-Liste in ListMonk ab.
+     *
+     * @param array $members Liste von ['id', 'username', 'firstname', 'lastname', 'email'] (Ldap::getAll())
+     * @return array{total:int,created:int,updated:int,removed:int,skipped:int,errors:string[]}
+     * @throws \RuntimeException wenn ListMonk nicht konfiguriert ist
+     */
+    public function sync(array $members): array
+    {
+        if (!$this->isConfigured()) {
+            throw new \RuntimeException('ListMonk ist nicht konfiguriert (LISTMONK_URL, LISTMONK_USER, LISTMONK_TOKEN, LISTMONK_LIST_ID).', 1750000001);
+        }
+
+        $created = $updated = $removed = $skipped = 0;
+        $errors = [];
+
+        // 1. Soll-Zustand aus den Mitgliedern bilden (.invalid-Adressen überspringen)
+        $desired = [];
+        foreach ($members as $member) {
+            $email = trim((string) ($member['email'] ?? ''));
+            if ($email === '' || preg_match('/\.invalid$/i', $email)) {
+                $skipped++;
+                continue;
+            }
+            $desired[mb_strtolower($email)] = [
+                'email' => $email,
+                'name' => trim(($member['firstname'] ?? '') . ' ' . ($member['lastname'] ?? '')),
+                'attribs' => [
+                    'mitgliedsnummer' => (int) ($member['id'] ?? 0),
+                    'vorname' => (string) ($member['firstname'] ?? ''),
+                    'nachname' => (string) ($member['lastname'] ?? ''),
+                ],
+            ];
+        }
+
+        // 2. Ist-Zustand: aktuelle Abonnenten der Ziel-Liste
+        $current = $this->getListSubscribers();
+
+        // 3. Anlegen / aktualisieren
+        foreach ($desired as $key => $entry) {
+            try {
+                if (isset($current[$key])) {
+                    if ($this->needsUpdate($current[$key], $entry)) {
+                        $this->updateSubscriber($current[$key], $entry, $this->listIdsOf($current[$key]));
+                        $updated++;
+                    }
+                } else {
+                    $this->createOrAdd($entry);
+                    $created++;
+                }
+            } catch (\Throwable $e) {
+                $errors[] = $entry['email'] . ': ' . $e->getMessage();
+            }
+        }
+
+        // 4. Voller Abgleich: Abonnenten der Liste entfernen, die kein aktuelles Mitglied (mehr) sind
+        $removeIds = [];
+        foreach ($current as $key => $subscriber) {
+            if (!isset($desired[$key])) {
+                $removeIds[] = (int) $subscriber['id'];
+            }
+        }
+        if ($removeIds) {
+            try {
+                $this->removeFromList($removeIds);
+                $removed = count($removeIds);
+            } catch (\Throwable $e) {
+                $errors[] = 'Entfernen aus der Liste fehlgeschlagen: ' . $e->getMessage();
+            }
+        }
+
+        return [
+            'total' => count($desired),
+            'created' => $created,
+            'updated' => $updated,
+            'removed' => $removed,
+            'skipped' => $skipped,
+            'errors' => $errors,
+        ];
+    }
+
+    /**
+     * Alle Abonnenten der Ziel-Liste, paginiert geladen.
+     *
+     * @return array<string,array> strtolower(email) => Abonnenten-Objekt von ListMonk
+     */
+    private function getListSubscribers(): array
+    {
+        $subscribers = [];
+        $page = 1;
+        $perPage = 1000;
+        do {
+            $query = http_build_query([
+                'list_id' => $this->listId,
+                'page' => $page,
+                'per_page' => $perPage,
+            ]);
+            [$status, $body] = $this->request('GET', '/api/subscribers?' . $query);
+            if ($status < 200 || $status >= 300) {
+                throw new \RuntimeException('Konnte Abonnenten nicht laden (HTTP ' . $status . ').', 1750000002);
+            }
+            $results = $body['data']['results'] ?? [];
+            foreach ($results as $subscriber) {
+                $email = trim((string) ($subscriber['email'] ?? ''));
+                if ($email !== '') {
+                    $subscribers[mb_strtolower($email)] = $subscriber;
+                }
+            }
+            $total = (int) ($body['data']['total'] ?? 0);
+            $page++;
+        } while ($results && count($subscribers) < $total);
+
+        return $subscribers;
+    }
+
+    /**
+     * Legt einen Abonnenten an. Existiert die E-Mail bereits global (nur nicht in dieser Liste),
+     * wird der Abonnent gesucht und der Ziel-Liste hinzugefügt (Status bleibt erhalten).
+     */
+    private function createOrAdd(array $entry): void
+    {
+        [$status, $body] = $this->request('POST', '/api/subscribers', [
+            'email' => $entry['email'],
+            'name' => $entry['name'],
+            'status' => 'enabled',
+            'lists' => [$this->listId],
+            'preconfirm_subscriptions' => true,
+            'attribs' => $entry['attribs'],
+        ]);
+
+        if ($status >= 200 && $status < 300) {
+            return;
+        }
+
+        // E-Mail existiert bereits: Abonnent suchen und der Liste hinzufügen
+        $existing = $this->findByEmail($entry['email']);
+        if ($existing === null) {
+            $message = $body['message'] ?? ('HTTP ' . $status);
+            throw new \RuntimeException('Anlegen fehlgeschlagen: ' . $message, 1750000003);
+        }
+
+        $listIds = $this->listIdsOf($existing);
+        if (!in_array($this->listId, $listIds, true)) {
+            $listIds[] = $this->listId;
+        }
+        $this->updateSubscriber($existing, $entry, $listIds);
+    }
+
+    /**
+     * Aktualisiert Name/Attribute eines Abonnenten. Listenmitgliedschaften und Status werden bewusst
+     * mitgegeben, da PUT in ListMonk alle Felder überschreibt.
+     *
+     * @param int[] $listIds beizubehaltende/zu setzende Listen-IDs
+     */
+    private function updateSubscriber(array $subscriber, array $entry, array $listIds): void
+    {
+        $id = (int) $subscriber['id'];
+        $attribs = array_merge(is_array($subscriber['attribs'] ?? null) ? $subscriber['attribs'] : [], $entry['attribs']);
+
+        [$status, $body] = $this->request('PUT', '/api/subscribers/' . $id, [
+            'email' => $entry['email'],
+            'name' => $entry['name'],
+            'status' => $subscriber['status'] ?? 'enabled',
+            'lists' => array_values($listIds),
+            'preconfirm_subscriptions' => true,
+            'attribs' => $attribs,
+        ]);
+
+        if ($status < 200 || $status >= 300) {
+            $message = $body['message'] ?? ('HTTP ' . $status);
+            throw new \RuntimeException('Aktualisieren fehlgeschlagen: ' . $message, 1750000004);
+        }
+    }
+
+    /**
+     * Entfernt Abonnenten aus der Ziel-Liste (löscht sie nicht global, andere Listen bleiben erhalten).
+     *
+     * @param int[] $ids
+     */
+    private function removeFromList(array $ids): void
+    {
+        foreach (array_chunk($ids, 1000) as $chunk) {
+            [$status, $body] = $this->request('PUT', '/api/subscribers/lists', [
+                'ids' => array_values($chunk),
+                'action' => 'remove',
+                'target_list_ids' => [$this->listId],
+            ]);
+            if ($status < 200 || $status >= 300) {
+                $message = $body['message'] ?? ('HTTP ' . $status);
+                throw new \RuntimeException($message, 1750000005);
+            }
+        }
+    }
+
+    /**
+     * Sucht einen Abonnenten anhand seiner E-Mail-Adresse.
+     */
+    private function findByEmail(string $email): ?array
+    {
+        $query = http_build_query([
+            'query' => "subscribers.email = '" . str_replace("'", "''", $email) . "'",
+            'per_page' => 1,
+        ]);
+        [$status, $body] = $this->request('GET', '/api/subscribers?' . $query);
+        if ($status < 200 || $status >= 300) {
+            return null;
+        }
+        return $body['data']['results'][0] ?? null;
+    }
+
+    /**
+     * Muss der Abonnent aktualisiert werden (Name oder relevante Attribute weichen ab)?
+     */
+    private function needsUpdate(array $subscriber, array $entry): bool
+    {
+        if (($subscriber['name'] ?? '') !== $entry['name']) {
+            return true;
+        }
+        $attribs = is_array($subscriber['attribs'] ?? null) ? $subscriber['attribs'] : [];
+        foreach ($entry['attribs'] as $key => $value) {
+            if (!array_key_exists($key, $attribs) || (string) $attribs[$key] !== (string) $value) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Listen-IDs eines Abonnenten-Objekts.
+     *
+     * @return int[]
+     */
+    private function listIdsOf(array $subscriber): array
+    {
+        $lists = $subscriber['lists'] ?? [];
+        if (!is_array($lists)) {
+            return [];
+        }
+        return array_values(array_map(fn($list) => (int) ($list['id'] ?? 0), $lists));
+    }
+
+    /**
+     * Führt einen ListMonk-API-Aufruf aus.
+     *
+     * @return array{0:int,1:array} [HTTP-Statuscode, dekodierter Body]
+     * @throws \RuntimeException bei Transportfehlern
+     */
+    private function request(string $method, string $path, ?array $body = null): array
+    {
+        $ch = curl_init($this->baseUrl . $path);
+
+        $headers = ['Accept: application/json'];
+        curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
+        curl_setopt($ch, CURLOPT_USERPWD, $this->apiUser . ':' . $this->apiToken);
+        curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
+        curl_setopt($ch, CURLOPT_TIMEOUT, 60);
+
+        if ($body !== null) {
+            $headers[] = 'Content-Type: application/json';
+            curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($body, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+        }
+        curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+
+        $response = curl_exec($ch);
+        if ($response === false) {
+            $error = curl_error($ch);
+            curl_close($ch);
+            throw new \RuntimeException('ListMonk nicht erreichbar: ' . $error, 1750000006);
+        }
+        $status = (int) curl_getinfo($ch, CURLINFO_RESPONSE_CODE);
+        curl_close($ch);
+
+        $decoded = json_decode((string) $response, true);
+        return [$status, is_array($decoded) ? $decoded : []];
+    }
+}

--- a/app/templates/AdminController/admin.latte
+++ b/app/templates/AdminController/admin.latte
@@ -14,6 +14,15 @@
 <p>Zeige die <a href="/search?fullName=&key0=resignation&op0=true">Liste der ausgetretenen Mitglieder</a> und klicke im Profil auf "Daten bearbeiten".</p>
 </section>
 
+<section n:if="currentUser()->hasRole('newsletter-export')" class="panel">
+<h2>ListMonk-Synchronisation</h2>
+<p>Gleicht Namen und E-Mail-Adressen aller Mitglieder mit der ListMonk-Liste ab. Ausgetretene oder gelöschte Mitglieder werden aus der Liste entfernt, Adressen mit <code>.invalid</code> übersprungen.</p>
+<form action="/admin/listmonk-sync" method="post">
+    {=csrfTokenTag()}
+    <button type="submit"><i class="ti ti-refresh" aria-hidden="true"></i> Jetzt synchronisieren</button>
+</form>
+</section>
+
 {if $groups}
     <section class="panel">
     <h2>Gruppenzuordnungen verwalten</h2>

--- a/app/templates/ListmonkController/sync-result.latte
+++ b/app/templates/ListmonkController/sync-result.latte
@@ -1,0 +1,32 @@
+{var $navId = admin}
+
+{block page-label}<i class="ti ti-mail-forward" aria-hidden="true"></i> ListMonk-Synchronisation{/block}
+
+{block title}ListMonk-Synchronisation{/block}
+
+{block content}
+<section class="panel">
+    <h2>Abgleich abgeschlossen</h2>
+
+    {if $result['errors']}
+        {include info-box, type: 'warning', text: 'Der Abgleich wurde durchgeführt, dabei sind Fehler aufgetreten (siehe unten).'}
+    {else}
+        {include info-box, type: 'success', text: 'Die Mitglieder wurden erfolgreich mit ListMonk abgeglichen.'}
+    {/if}
+
+    <ul>
+        <li><strong>{$result['total']}</strong> Mitglieder mit gültiger E-Mail-Adresse</li>
+        <li><strong>{$result['created']}</strong> neu zur Liste hinzugefügt</li>
+        <li><strong>{$result['updated']}</strong> aktualisiert (Name/Attribute)</li>
+        <li><strong>{$result['removed']}</strong> aus der Liste entfernt</li>
+        <li><strong>{$result['skipped']}</strong> übersprungen (ungültige <code>.invalid</code>-Adresse)</li>
+    </ul>
+
+    <p n:if=$result['errors']>Fehler:</p>
+    <ol n:ifcontent n:inner-foreach="$result['errors'] as $error">
+        <li>{$error}</li>
+    </ol>
+
+    <p><a href="/admin">zurück zur Mitgliederverwaltung</a></p>
+</section>
+{/block}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,11 @@ services:
       - SMTP_USER
       - SMTP_PASSWORD
       - FROM_ADDRESS
+      - LISTMONK_URL
+      - LISTMONK_USER
+      - LISTMONK_TOKEN
+      - LISTMONK_LIST_ID
+      - LISTMONK_SYNC_TOKEN
     labels:
       - traefik.enable=true
       - traefik.http.routers.${SERVICENAME}.middlewares=secheader@file

--- a/env.sample
+++ b/env.sample
@@ -16,3 +16,13 @@ SMTP_PORT=465
 SMTP_USER=
 SMTP_PASSWORD=
 FROM_ADDRESS=
+
+# ListMonk-Synchronisation (Namen + E-Mail-Adressen der Mitglieder)
+# Leer lassen, um das Feature zu deaktivieren.
+LISTMONK_URL=
+LISTMONK_USER=
+LISTMONK_TOKEN=
+LISTMONK_LIST_ID=
+# Geheimer Token für den Cron-Endpoint, z.B. per Crontab:
+#   curl -fsS "https://mitglieder.<domain>/cron/listmonk-sync?token=..."
+LISTMONK_SYNC_TOKEN=


### PR DESCRIPTION
Mechanismus, der Namen und E-Mail-Adressen der Mitglieder über die ListMonk-API mit einer Ziel-Liste abgleicht. Quelle der Wahrheit ist (wie beim bestehenden CSV-Export) das LDAP.

- Listmonk-Service: voller Abgleich (anlegen/aktualisieren/entfernen), .invalid-Adressen werden übersprungen; andere Listen/Status bleiben erhalten
- Auslöser: Admin-Button (Rolle newsletter-export) und token-geschützter Cron-Endpoint (GET /cron/listmonk-sync)
- Konfiguration über LISTMONK_* in env.sample und docker-compose.yml